### PR TITLE
feat(recallengine): add Timeout option to RecallOptions

### DIFF
--- a/recallengine/request.go
+++ b/recallengine/request.go
@@ -5,7 +5,8 @@ type Request struct {
 }
 
 type RecallOptions struct {
-	TriggerLimit int `json:"trigger_limit,omitempty"`
+	TriggerLimit int `json:"trigger_limit,omitempty"` // per-trigger recall limit, 0 means no limit
+	Timeout      int `json:"timeout,omitempty"`       // per-way recall timeout in milliseconds, 0 means no per-way timeout
 }
 
 type RecallConf struct {


### PR DESCRIPTION
支持在 RecallOptions 中配置单路召回超时时间（毫秒）。

- 新增 Timeout 字段，JSON tag 为 timeout,omitempty，0 表示不设置单路超时